### PR TITLE
Cleanup Readme to remove mentions of specific companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # AngularToDoCucumber
-This is the UI automation coding exercise for SignalPath, to demonstrate my ability to do the following.
+This is the UI automation coding example, to demonstrate my ability to do the following.
 
 * Start up a UI automation framework
 * Utilize said framework to write working automation
 * Show coding style and structure
+
+This utilizes the online test angular service found [here](http://todomvc.com/examples/angular2/)
 
 ## Prerequisites
 * Install [rbenv](https://github.com/rbenv/rbenv) with [ruby-build](https://github.com/rbenv/ruby-build)


### PR DESCRIPTION
 - Add entry to point to the Angular2 sandbox page 
 - Remove mention of the company SignalPath